### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: Quality Gate CI
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   quality-gate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/basher83/dagger-quality-gate/security/code-scanning/2](https://github.com/basher83/dagger-quality-gate/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow. This block will specify the least privileges required for the workflow to function correctly. Since the workflow primarily reads repository contents and does not perform write operations, we will set `contents: read` at the root level of the workflow. This will apply to all jobs unless overridden by a job-specific `permissions` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
